### PR TITLE
Ignore file changes in `.ipynb_checkpoints/`

### DIFF
--- a/supervisord/conf.d/mockbook.conf
+++ b/supervisord/conf.d/mockbook.conf
@@ -1,4 +1,4 @@
 [program:mockbook]
 directory = /app
-command = uvicorn mockbook.main:app --host 0.0.0.0 --reload --reload-dir /app/mockbook --reload-include '*.ipynb'
+command = uvicorn mockbook.main:app --host 0.0.0.0 --reload --reload-dir /app/mockbook --reload-include '*.ipynb' --reload-exclude '.ipynb_checkpoints/*'
 autorestart = true


### PR DESCRIPTION
Ignore unwanted file changes triggering FastAPI reload.