### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   lint:
@@ -22,7 +23,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,6 @@ on:
     branches: ["main"]
     tags: ["v*"]
 
-permissions: read-all
-
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ install:  ## Install deps
 	git submodule update --init --recursive --remote
 	pre-commit install --install-hooks
 	uv python install
-	uv sync --frozen --all-packages --all-extras
+	uv sync --frozen
 .PHONY: install
 
 update:  ## Update deps and tools
-	uv sync --upgrade --all-extras
+	uv sync --upgrade
 	pre-commit autoupdate
 .PHONY: update
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "factory-boy~=3.3.1",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["mypy~=1.16.0", "ruff~=0.12.1", "types-requests>=2.32.0.20250328"]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -826,7 +826,7 @@ dependencies = [
     { name = "nbformat" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "ruff" },
@@ -839,12 +839,15 @@ requires-dist = [
     { name = "faker", specifier = "~=37.4.0" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.4" },
     { name = "jupyterlab", specifier = "~=4.4.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.16.0" },
     { name = "nbformat", specifier = "~=5.10.4" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.12.1" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20250328" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = "~=1.16.0" },
+    { name = "ruff", specifier = "~=0.12.1" },
+    { name = "types-requests", specifier = ">=2.32.0.20250328" },
+]
 
 [[package]]
 name = "mypy"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.